### PR TITLE
Update rails command in docker-compose template

### DIFF
--- a/lib/railsdock/templates/install/default/docker-compose.yml.erb
+++ b/lib/railsdock/templates/install/default/docker-compose.yml.erb
@@ -33,7 +33,7 @@ services:
 
   rails:
     <<: *ruby-base
-    command: rails server -p 3000 -b '0.0.0.0'
+    command: bundle exec rails server -p 3000 -b '0.0.0.0'
     entrypoint: ./docker/ruby/entrypoint.sh
     ports:
       - "${RAILS_SERVER_HOST_PORT}:3000"


### PR DESCRIPTION
Rails service fails due to command in docker-compose template. Update the command to `bundle exec` the rails command.

fixes #20 